### PR TITLE
Destroy action creator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 1.1.0 (May 8, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.
- - Added `destroySplitSdk` action creator to gracefully shut down the SDK.
- - Added two new status properties to split's piece of state: `hasTimedout` and `isDestroyed`.
+ - Added `destroySplitSdk` action creator to gracefully shutdown the SDK.
+ - Added two new status properties to split's piece of state: `hasTimedout` and `isDestroyed` to better reflect the current state of the associated factory.
 
 1.0.1 (April 6, 2020)
  - Updated dependencies to fix vulnerabilities

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
-1.0.2 (May XXX, 2020)
+1.1.0 (May 8, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.
+ - Added `destroySplitSdk` action creator to gracefully shut down the SDK.
+ - Added two new status properties to split's piece of state: `hasTimedout` and `isDestroyed`.
 
 1.0.1 (April 6, 2020)
  - Updated dependencies to fix vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-redux",
-  "version": "1.0.2-canary.0",
+  "version": "1.1.0-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -486,6 +486,12 @@
         "@types/node": "*"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/enzyme": {
       "version": "3.10.4",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.4.tgz",
@@ -684,9 +690,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1290,12 +1296,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
@@ -3094,12 +3094,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
-    },
     "ioredis": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.16.3.tgz",
@@ -4047,15 +4041,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -4208,15 +4193,6 @@
         "tmpl": "1.0.x"
       }
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4230,17 +4206,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
       }
     },
     "merge-stream": {
@@ -4284,12 +4249,6 @@
       "requires": {
         "mime-db": "1.42.0"
       }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4480,12 +4439,6 @@
         "boolbase": "~1.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -4664,23 +4617,6 @@
         "word-wrap": "~1.2.3"
       }
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -4694,12 +4630,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -5134,135 +5064,158 @@
       "dev": true
     },
     "replace": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/replace/-/replace-1.1.5.tgz",
-      "integrity": "sha512-Mww6GyTix4GqN1GSbJDkUzftkjQE0xfzzlGkFF26ukm8DBzgwGPFntvmVsvAKJogwSSMjvAoZei7fJ2tfiKMcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/replace/-/replace-1.2.0.tgz",
+      "integrity": "sha512-e3AP5GkRk+N/Qm1MUBaMhEHr4X3sHNI44a8m4ww6/qShJphTsStxSezbYtFNTFGCXZtWrwz4McVvCEwBv+ebAw==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
         "minimatch": "3.0.4",
-        "yargs": "^12.0.5"
+        "yargs": "^15.3.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
+            "cliui": "^6.0.0",
             "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^4.2.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
           }
         },
         "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -6425,9 +6378,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-redux",
-  "version": "1.0.2-canary.0",
+  "version": "1.1.0-canary.0",
   "description": "A library to easily use Split JS SDK with Redux and React Redux",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -74,7 +74,7 @@
     "redux": "3.7.2",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0",
-    "replace": "^1.1.5",
+    "replace": "^1.2.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.2.0",
     "tslint": "^5.20.1",

--- a/src/__tests__/actions.browser.test.ts
+++ b/src/__tests__/actions.browser.test.ts
@@ -382,9 +382,3 @@ describe('destroySplitSdk', () => {
   });
 
 });
-
-/**
- * TODO other tests:
- * - __addEvalOnUpdate, __removeEvalOnUpdate, __getSplitKeyString
- * - __getTreatments
- */

--- a/src/__tests__/actions.browser.test.ts
+++ b/src/__tests__/actions.browser.test.ts
@@ -10,10 +10,10 @@ import { STATE_INITIAL } from './utils/storeState';
 import { sdkBrowserLocalhost } from './utils/sdkConfigs';
 
 /** Constants and types */
-import { SPLIT_READY, SPLIT_TIMEDOUT, SPLIT_UPDATE, ADD_TREATMENTS, ERROR_GETT_NO_INITSPLITSDK, getControlTreatmentsWithConfig } from '../constants';
+import { SPLIT_READY, SPLIT_TIMEDOUT, SPLIT_UPDATE, SPLIT_DESTROY, ADD_TREATMENTS, ERROR_GETT_NO_INITSPLITSDK, ERROR_DESTROY_NO_INITSPLITSDK, getControlTreatmentsWithConfig } from '../constants';
 
 /** Test targets */
-import { initSplitSdk, getTreatments, splitSdk, getClient } from '../asyncActions';
+import { initSplitSdk, getTreatments, destroySplitSdk, splitSdk, getClient } from '../asyncActions';
 
 describe('initSplitSdk', () => {
 
@@ -331,10 +331,60 @@ describe('getTreatments providing a user key', () => {
     });
   });
 
-  /**
-   * TODO other tests:
-   * - __addEvalOnUpdate, __removeEvalOnUpdate, __getSplitKeyString
-   * - __getTreatments
-   */
+});
+
+describe('destroySplitSdk', () => {
+
+  beforeEach(() => {
+    splitSdk.factory = null;
+    splitSdk.config = null;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs error and dispatches a no-op async action that returns a resolved promise if Split SDK was not initialized', () => {
+    const errorSpy = jest.spyOn(console, 'error');
+    const store = mockStore(STATE_INITIAL);
+
+    store.dispatch<any>(destroySplitSdk()).then(() => {
+      expect(errorSpy).toBeCalledWith(ERROR_DESTROY_NO_INITSPLITSDK);
+      expect(store.getActions().length).toBe(0);
+    });
+  });
+
+  it('returns a promise and dispatch SPLIT_DESTROY actions when clients are destroyed', (done) => {
+    const store = mockStore(STATE_INITIAL);
+    const actionResult = store.dispatch<any>(initSplitSdk({ config: sdkBrowserLocalhost }));
+    (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
+
+    actionResult.then(() => {
+      // we dispatch some `getTreatments` with different user keys to create new clients
+      store.dispatch<any>(getTreatments({ splitNames: 'split2', key: 'other-user-key' }));
+      store.dispatch<any>(getTreatments({ splitNames: 'split3', key: 'other-user-key-2' }));
+
+      const timestamp = Date.now();
+      const actionResult = store.dispatch<any>(destroySplitSdk());
+
+      actionResult.then(() => {
+        const action = store.getActions()[3];
+        expect(action.type).toEqual(SPLIT_DESTROY);
+        expect(action.payload.timestamp).toBeLessThanOrEqual(Date.now());
+        expect(action.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+        // assert that all client's destroy methods were called
+        expect((splitSdk.factory as any).client().destroy.mock.calls.length).toBe(1);
+        expect((splitSdk.factory as any).client('other-user-key').destroy.mock.calls.length).toBe(1);
+        expect((splitSdk.factory as any).client('other-user-key-2').destroy.mock.calls.length).toBe(1);
+        done();
+      }, 0);
+    });
+  });
 
 });
+
+/**
+ * TODO other tests:
+ * - __addEvalOnUpdate, __removeEvalOnUpdate, __getSplitKeyString
+ * - __getTreatments
+ */

--- a/src/__tests__/reducer.test.ts
+++ b/src/__tests__/reducer.test.ts
@@ -1,11 +1,12 @@
 import reducer from '../reducer';
-import { splitReady, splitTimedout, splitUpdate, addTreatments } from '../actions';
+import { splitReady, splitTimedout, splitUpdate, addTreatments, splitDestroy } from '../actions';
 import { ISplitState } from '../types';
 
 const initialState = {
   isReady: false,
   isTimedout: false,
   hasTimedout: false,
+  isDestroyed: false,
   lastUpdate: 0,
   treatments: {},
 };
@@ -59,6 +60,17 @@ describe('Split reducer', () => {
     ).toEqual({
       ...initialState,
       lastUpdate: updateAction.payload.timestamp,
+    });
+  });
+
+  it('should handle SPLIT_DESTROY', () => {
+    const destroyAction = splitDestroy();
+    expect(
+      reducer(initialState, destroyAction),
+    ).toEqual({
+      ...initialState,
+      isDestroyed: true,
+      lastUpdate: destroyAction.payload.timestamp,
     });
   });
 

--- a/src/__tests__/utils/mockBrowserSplitSdk.ts
+++ b/src/__tests__/utils/mockBrowserSplitSdk.ts
@@ -57,11 +57,15 @@ export function mockSdk() {
           __isTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
         });
       });
+      const destroy: jest.Mock = jest.fn(() => {
+        return new Promise((res, rej) => { setTimeout(res, 100); });
+      });
 
       return Object.assign(Object.create(__emitter__), {
         getTreatmentsWithConfig,
         track,
         ready,
+        destroy,
         Event,
         // EventEmitter exposed to trigger events manually
         __emitter__,

--- a/src/__tests__/utils/mockNodeSplitSdk.ts
+++ b/src/__tests__/utils/mockNodeSplitSdk.ts
@@ -27,11 +27,15 @@ function mockClient() {
       __isTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
     });
   });
+  const destroy: jest.Mock = jest.fn(() => {
+    return new Promise((res, rej) => { setTimeout(res, 100); });
+  });
 
   return Object.assign(Object.create(__emitter__), {
     getTreatmentsWithConfig,
     track,
     ready,
+    destroy,
     Event,
     // EventEmitter exposed to trigger events manually
     __emitter__,

--- a/src/__tests__/utils/mockStore.ts
+++ b/src/__tests__/utils/mockStore.ts
@@ -1,8 +1,9 @@
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
+import { ISplitState } from '../../types';
 const middlewares = [thunk];
 
 /**
  * Utils to not call requires files every time that we need mock the store
  */
-export default configureMockStore(middlewares);
+export default configureMockStore<{ splitio: ISplitState }>(middlewares);

--- a/src/__tests__/utils/mockStore.ts
+++ b/src/__tests__/utils/mockStore.ts
@@ -1,6 +1,5 @@
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-import { ISplitState } from '../../types';
 const middlewares = [thunk];
 
 /**

--- a/src/__tests__/utils/mockStore.ts
+++ b/src/__tests__/utils/mockStore.ts
@@ -6,4 +6,4 @@ const middlewares = [thunk];
 /**
  * Utils to not call requires files every time that we need mock the store
  */
-export default configureMockStore<{ splitio: ISplitState }>(middlewares);
+export default configureMockStore(middlewares);

--- a/src/__tests__/utils/storeState.ts
+++ b/src/__tests__/utils/storeState.ts
@@ -14,6 +14,7 @@ export const STATE_READY: { splitio: ISplitState } = {
     isReady: true,
     isTimedout: false,
     hasTimedout: false,
+    isDestroyed: false,
     lastUpdate: 1192838123,
     treatments: {
       [SPLIT_1]: {
@@ -31,6 +32,7 @@ export const STATE_INITIAL: { splitio: ISplitState } = {
     isReady: false,
     isTimedout: false,
     hasTimedout: false,
+    isDestroyed: false,
     lastUpdate: 0,
     treatments: {
     },

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@
  * Common action creators for browser and node.
  * They return plain actions (Flux-Standard-Actions).
  */
-import { SPLIT_READY, SPLIT_UPDATE, SPLIT_TIMEDOUT, ADD_TREATMENTS } from './constants';
+import { SPLIT_READY, SPLIT_UPDATE, SPLIT_TIMEDOUT, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
 import { matching } from './utils';
 
 export function splitReady() {
@@ -26,6 +26,15 @@ export function splitUpdate() {
 export function splitTimedout() {
   return {
     type: SPLIT_TIMEDOUT,
+    payload: {
+      timestamp: Date.now(),
+    },
+  };
+}
+
+export function splitDestroy() {
+  return {
+    type: SPLIT_DESTROY,
     payload: {
       timestamp: Date.now(),
     },

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -1,6 +1,6 @@
 import { SplitFactory } from '@splitsoftware/splitio';
 import { Dispatch, Action } from 'redux';
-import { ISplitSdk, IInitSplitSdkParams, IGetTreatmentsParams, ISplitFactoryBuilder, IClientNotDetached } from './types';
+import { ISplitSdk, IInitSplitSdkParams, IGetTreatmentsParams, ISplitFactoryBuilder } from './types';
 import { splitReady, splitTimedout, splitUpdate, splitDestroy, addTreatments } from './actions';
 import { VERSION, ERROR_GETT_NO_INITSPLITSDK, ERROR_DESTROY_NO_INITSPLITSDK, getControlTreatmentsWithConfig } from './constants';
 import { matching } from './utils';
@@ -154,9 +154,20 @@ export function getTreatments(params: IGetTreatmentsParams) {
 }
 
 /**
+ * Interface of SDK client for not detached execution (browser).
+ */
+interface IClientNotDetached extends SplitIO.IClient {
+  _trackingStatus?: boolean;
+  isReady: boolean;
+  evalOnUpdate: { [splitNameSplitKeyPair: string]: IGetTreatmentsParams }; // redoOnUpdateOrReady
+  evalOnReady: IGetTreatmentsParams[]; // waitUntilReady
+}
+
+/**
  * Used in not detached version (browser). It gets an SDK client and enhance it with additional properties:
  *  - `isReady` status property.
  *  - `evalOnUpdate` and `evalOnReady` action lists.
+ * It is exported for testing purposes only.
  *
  * @param splitSdk it contains the Split factory, the store dispatch function, and other internal properties
  * @param key optional user key

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -171,7 +171,7 @@ export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientN
 
   if (client._trackingStatus) return client;
 
-  splitSdk.clients[stringKey] = client;
+  if (!isMainClient) splitSdk.sharedClients[stringKey] = client;
   client._trackingStatus = true;
   client.isReady = false;
   client.evalOnUpdate = {}; // getTreatment actions stored to execute on SDK update
@@ -225,8 +225,10 @@ export function destroySplitSdk() {
         dispatch(splitDestroy());
       });
     } else {
-      // @TODO update once JS SDK shutdown is updated to support destroy of shared clients
-      const destroyPromises = Object.keys(splitSdk.clients).map((clientKey) => splitSdk.clients[clientKey].destroy());
+      const mainClient = splitSdk.factory.client();
+      const sharedClients = splitSdk.sharedClients;
+      const destroyPromises = Object.keys(sharedClients).map((clientKey) => sharedClients[clientKey].destroy());
+      destroyPromises.push(mainClient.destroy());
       return Promise.all(destroyPromises).then(function() {
         dispatch(splitDestroy());
       });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,10 +29,14 @@ export const SPLIT_UPDATE = 'SPLIT_UPDATE';
 
 export const SPLIT_TIMEDOUT = 'SPLIT_TIMEDOUT';
 
+export const SPLIT_DESTROY = 'SPLIT_DESTROY';
+
 export const ADD_TREATMENTS = 'ADD_TREATMENTS';
 
 // Warning and error messages
 export const ERROR_GETT_NO_INITSPLITSDK = '[Error] To use "getTreatments" the SDK must be first initialized with a "initSplitSdk" action';
+
+export const ERROR_DESTROY_NO_INITSPLITSDK = '[Error] To use "destroySplitSdk" the SDK must be first initialized with a "initSplitSdk" action';
 
 export const ERROR_TRACK_NO_INITSPLITSDK = '[Error] To use "track" the SDK must be first initialized with an "initSplitSdk" action';
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ import { ERROR_TRACK_NO_INITSPLITSDK, ERROR_MANAGER_NO_INITSPLITSDK } from './co
  *
  * @param {ITrackParams} params
  *
- * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#track}
+ * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#track}
  */
 export function track(params: ITrackParams): boolean {
   if (!splitSdk.factory) {
@@ -41,7 +41,7 @@ export function track(params: ITrackParams): boolean {
  *
  * @returns {string[]} The list of Split names. The list might be empty if the SDK was not initialized or if it's not ready yet.
  *
- * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#manager}
+ * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#manager}
  */
 export function getSplitNames(): string[] {
   if (!splitSdk.factory) {
@@ -58,7 +58,7 @@ export function getSplitNames(): string[] {
  * @param {string} splitName The name of the split we wan't to get info of.
  * @returns {SplitView} The SplitIO.SplitView of the given split, or null if split does not exist or the SDK was not initialized or is not ready.
  *
- * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#manager}
+ * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#manager}
  */
 export function getSplit(splitName: string): SplitIO.SplitView {
   if (!splitSdk.factory) {
@@ -74,7 +74,7 @@ export function getSplit(splitName: string): SplitIO.SplitView {
  *
  * @returns {SplitViews} The list of SplitIO.SplitView. The list might be empty if the SDK was not initialized or if it's not ready yet
  *
- * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#manager}
+ * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#manager}
  */
 export function getSplits(): SplitIO.SplitViews {
   if (!splitSdk.factory) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // For Redux
 export { default as splitReducer } from './reducer';
-export { initSplitSdk, getTreatments, splitSdk } from './asyncActions';
+export { initSplitSdk, getTreatments, destroySplitSdk, splitSdk } from './asyncActions';
 export { track, getSplitNames, getSplit, getSplits } from './helpers';
 export { selectTreatmentValue, selectTreatmentWithConfig } from './selectors';
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,6 +1,6 @@
 import { Reducer } from 'redux';
 import { ISplitState } from './types';
-import { SPLIT_READY, SPLIT_TIMEDOUT, SPLIT_UPDATE, ADD_TREATMENTS } from './constants';
+import { SPLIT_READY, SPLIT_TIMEDOUT, SPLIT_UPDATE, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
 
 /**
  * Initial default state for Split reducer
@@ -9,6 +9,7 @@ const initialState: ISplitState = {
   isReady: false,
   isTimedout: false,
   hasTimedout: false,
+  isDestroyed: false,
   lastUpdate: 0,
   treatments: {},
 };
@@ -41,6 +42,13 @@ const splitReducer: Reducer<ISplitState> = function(
     case SPLIT_UPDATE:
       return {
         ...state,
+        lastUpdate: action.payload.timestamp,
+      };
+
+    case SPLIT_DESTROY:
+      return {
+        ...state,
+        isDestroyed: true,
         lastUpdate: action.payload.timestamp,
       };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export interface ISplitSdk {
   config: SplitIO.IBrowserSettings | SplitIO.INodeSettings;
   splitio: ISplitFactoryBuilder;
   factory: SplitIO.ISDK;
+  clients: { [stringKey: string]: SplitIO.IClient };
   isDetached: boolean;
   dispatch: Dispatch<Action>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,32 +3,32 @@ export interface ISplitState {
 
   /**
    * isReady indicates if Split SDK is ready, i.e., if it has triggered a SDK_READY event.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#advanced-subscribe-to-events-and-changes}
    */
   isReady: boolean;
 
   /**
    * isTimedout indicates if the Split SDK has triggered a SDK_READY_TIMED_OUT event and is not ready.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#advanced-subscribe-to-events-and-changes}
    */
   isTimedout: boolean;
 
   /**
    * hasTimedout indicates if the Split SDK has triggered a SDK_READY_TIMED_OUT event.
    * It differs from `isTimedout` in that it doesn't change when SDK turns ready.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#advanced-subscribe-to-events-and-changes}
    */
   hasTimedout: boolean;
 
   /**
    * isDestroyed indicates if the Split SDK has been destroyed by dispatching a `destroySplitSdk` action.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#shutdown}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#shutdown}
    */
   isDestroyed: boolean;
 
   /**
    * lastUpdate is the timestamp of the last Split SDK event (SDK_READY, SDK_READY_TIMED_OUT or SDK_UPDATE).
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#advanced-subscribe-to-events-and-changes}
    */
   lastUpdate: number;
 
@@ -65,7 +65,7 @@ export interface IInitSplitSdkParams {
 
   /**
    * Setting object used to initialize the Split factory.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#configuration}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#configuration}
    */
   config: SplitIO.IBrowserSettings | SplitIO.INodeSettings;
 
@@ -109,7 +109,7 @@ export interface IGetTreatmentsParams {
 
   /**
    * optional map of attributes passed to the actual `client.getTreatment*` methods.
-   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#attribute-syntax}
+   * @see {@link https://help.split.io/hc/en-us/articles/360038851551-Redux-SDK#attribute-syntax}
    */
   attributes?: SplitIO.Attributes;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,19 +157,3 @@ export interface ITrackParams {
 }
 
 export type ISplitFactoryBuilder = (settings: SplitIO.IBrowserSettings | SplitIO.INodeSettings) => SplitIO.ISDK;
-
-import { Dispatch, Action } from 'redux';
-
-/**
- * Type of internal object SplitSdk. This object should not be accessed or
- * modified by the user, since it is not considered part of the public API
- * and may break without notice. It is used by the library for its operation.
- */
-export interface ISplitSdk {
-  config: SplitIO.IBrowserSettings | SplitIO.INodeSettings;
-  splitio: ISplitFactoryBuilder;
-  factory: SplitIO.ISDK;
-  sharedClients: { [stringKey: string]: SplitIO.IClient };
-  isDetached: boolean;
-  dispatch: Dispatch<Action>;
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,7 +168,7 @@ export interface ISplitSdk {
   config: SplitIO.IBrowserSettings | SplitIO.INodeSettings;
   splitio: ISplitFactoryBuilder;
   factory: SplitIO.ISDK;
-  clients: { [stringKey: string]: SplitIO.IClient };
+  sharedClients: { [stringKey: string]: SplitIO.IClient };
   isDetached: boolean;
   dispatch: Dispatch<Action>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,12 @@ export interface ISplitState {
   hasTimedout: boolean;
 
   /**
+   * isDestroyed indicates if the Split SDK has been destroyed by dispatching a `destroySplitSdk` action.
+   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#shutdown}
+   */
+  isDestroyed: boolean;
+
+  /**
    * lastUpdate is the timestamp of the last Split SDK event (SDK_READY, SDK_READY_TIMED_OUT or SDK_UPDATE).
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,8 +161,9 @@ export type ISplitFactoryBuilder = (settings: SplitIO.IBrowserSettings | SplitIO
 import { Dispatch, Action } from 'redux';
 
 /**
- * Type of internal object SplitSdk.
- * This object should not be accessed or modified by the user. It is used by the library for its operation.
+ * Type of internal object SplitSdk. This object should not be accessed or
+ * modified by the user, since it is not considered part of the public API
+ * and may break without notice. It is used by the library for its operation.
  */
 export interface ISplitSdk {
   config: SplitIO.IBrowserSettings | SplitIO.INodeSettings;
@@ -171,14 +172,4 @@ export interface ISplitSdk {
   sharedClients: { [stringKey: string]: SplitIO.IClient };
   isDetached: boolean;
   dispatch: Dispatch<Action>;
-}
-
-/**
- * Interface of SDK client for not detached execution (browser).
- */
-export interface IClientNotDetached extends SplitIO.IClient {
-  _trackingStatus?: boolean;
-  isReady: boolean;
-  evalOnUpdate: { [splitNameSplitKeyPair: string]: IGetTreatmentsParams }; // redoOnUpdateOrReady
-  evalOnReady: IGetTreatmentsParams[]; // waitUntilReady
 }


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?

- Added `destroySplitSdk`, a new thunk (async) action creator to destroy de SDK.
- Added the boolean property `isDestroyed` in the state.
- Updated references to public documentation (changed links from JS SDK to Redux SDK).

## How do we test the changes introduced in this PR?

Unit and integration tests

## Extra Notes