### PR TITLE
Support for READY_FROM_CACHE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.2.0 (Jul XX, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.13.0, which uses streaming synchronization by default, amongst other updates. Learn more in our javascript-client changelog or documentation.
+ - Added a new status property to split's piece of state: `isReadyFromCache` to indicate that the SDK is ready to evaluate when using LocalStorage cached data in browser.
 
 1.1.0 (May 11, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 1.2.0 (Jul XX, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.13.0, which uses streaming synchronization by default, amongst other updates. Learn more in our javascript-client changelog or documentation.
  - Added a new status property to split's piece of state: `isReadyFromCache` to indicate that the SDK is ready to evaluate when using LocalStorage cached data in browser.
+ - Added a new callback parameter to `initSplitSdk` action creator: `onReadyFromCache` to listen when the SDK is ready to evaluate using LocalStorage cached data.
 
 1.1.0 (May 11, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.

--- a/src/__tests__/actions.browser.test.ts
+++ b/src/__tests__/actions.browser.test.ts
@@ -172,7 +172,49 @@ describe('getTreatments', () => {
     });
   });
 
-  it('stores control treatments (without calling SDK client) and registers an ADD_TREATMENTS action if Split SDK is not ready, and dispatch it when ready', (done) => {
+  it('dispatches an ADD_TREATMENTS action and registers an ADD_TREATMENTS action if Split SDK is ready from cache, to dispatch it when ready', (done) => {
+
+    // Init SDK and set ready from cache
+    const store = mockStore(STATE_INITIAL);
+    const actionResult = store.dispatch<any>(initSplitSdk({ config: sdkBrowserLocalhost, onReadyFromCache: onReadyFromCacheCb }));
+    (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY_FROM_CACHE);
+
+    function onReadyFromCacheCb() {
+      store.dispatch<any>(getTreatments({ splitNames: 'split1' }));
+
+      let action = store.getActions()[1]; // action 0 is SPLIT_READY_FROM_CACHE
+      expect(action.type).toBe('ADD_TREATMENTS');
+      expect(action.payload.key).toBe(sdkBrowserLocalhost.core.key);
+      // Splits are evaluated if ready from cache
+      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).lastCalledWith(['split1'], undefined);
+      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
+      expect(getClient(splitSdk).evalOnUpdate).toEqual({});
+      expect(getClient(splitSdk).evalOnReady.length).toEqual(1);
+
+      (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
+
+      actionResult.then(() => {
+        // The ADD_TREATMENTS action is dispatched again once the SDK is ready
+        action = store.getActions()[3]; // action 2 is SPLIT_READY
+        expect(action.type).toBe(ADD_TREATMENTS);
+        expect(action.payload.key).toBe(sdkBrowserLocalhost.core.key);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).lastCalledWith(['split1'], undefined);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
+        expect(getClient(splitSdk).evalOnUpdate).toEqual({});
+
+        // The same action is dispatched again, but this time is registered for 'evalOnUpdate'
+        store.dispatch<any>(getTreatments({ splitNames: 'split1', evalOnUpdate: true }));
+
+        expect(store.getActions()[3]).toEqual(store.getActions()[4]);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toBeCalledTimes(3);
+        expect(Object.values(getClient(splitSdk).evalOnUpdate).length).toBe(1);
+
+        done();
+      });
+    }
+  });
+
+  it('stores control treatments (without calling SDK client) and registers an ADD_TREATMENTS action if Split SDK is not operational, to dispatch it when ready', (done) => {
 
     const store = mockStore(STATE_INITIAL);
     const actionResult = store.dispatch<any>(initSplitSdk({ config: sdkBrowserLocalhost }));
@@ -211,7 +253,7 @@ describe('getTreatments', () => {
     });
   });
 
-  it('stores control treatments (without calling SDK client) and registers an ADD_TREATMENTS action if Split SDK is not ready, and dispatch it when ready and updated', (done) => {
+  it('stores control treatments (without calling SDK client) and registers an ADD_TREATMENTS action if Split SDK is not operational, to dispatch it when ready and updated', (done) => {
 
     const store = mockStore(STATE_INITIAL);
     const actionResult = store.dispatch<any>(initSplitSdk({ config: sdkBrowserLocalhost }));

--- a/src/__tests__/actions.node.test.ts
+++ b/src/__tests__/actions.node.test.ts
@@ -27,7 +27,7 @@ describe('initSplitSdk', () => {
     jest.clearAllMocks();
   });
 
-  it('invokes callbacks and creates SPLIT_READY actions when SDK_READY event is triggered', (done) => {
+  it('invokes callbacks and dispatches SPLIT_READY actions when SDK_READY event is triggered', (done) => {
     const store = mockStore(STATE_INITIAL);
     const onReadyCb = jest.fn();
     const onUpdateCb = jest.fn();
@@ -52,7 +52,7 @@ describe('initSplitSdk', () => {
     });
   });
 
-  it('invokes callbacks and creates SPLIT_TIMEDOUT and then SPLIT_READY actions when SDK_READY_TIMED_OUT and SDK_READY events are triggered', (done) => {
+  it('invokes callbacks and dispatches SPLIT_TIMEDOUT and then SPLIT_READY actions when SDK_READY_TIMED_OUT and SDK_READY events are triggered', (done) => {
     const store = mockStore(STATE_INITIAL);
     const onReadyCb = jest.fn();
     const onTimedoutCb = jest.fn();
@@ -84,8 +84,6 @@ describe('initSplitSdk', () => {
 
   it('returns a promise that rejects on SDK_READY_TIMED_OUT', async (done) => {
     const store = mockStore(STATE_INITIAL);
-    const onReadyCb = jest.fn();
-    const onTimedoutCb = jest.fn();
     try {
       setTimeout(() => { (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY_TIMED_OUT, 'SDK_READY_TIMED_OUT'); }, 100);
       await store.dispatch<any>(initSplitSdk({ config: sdkNodeConfig}));

--- a/src/__tests__/reducer.test.ts
+++ b/src/__tests__/reducer.test.ts
@@ -1,9 +1,10 @@
 import reducer from '../reducer';
-import { splitReady, splitTimedout, splitUpdate, addTreatments, splitDestroy } from '../actions';
+import { splitReady, splitReadyFromCache, splitTimedout, splitUpdate, addTreatments, splitDestroy } from '../actions';
 import { ISplitState } from '../types';
 
 const initialState = {
   isReady: false,
+  isReadyFromCache: false,
   isTimedout: false,
   hasTimedout: false,
   isDestroyed: false,
@@ -23,6 +24,17 @@ describe('Split reducer', () => {
     ).toEqual({
       ...initialState,
       isReady: true,
+      lastUpdate: readyAction.payload.timestamp,
+    });
+  });
+
+  it('should handle SPLIT_READY_FROM_CACHE', () => {
+    const readyAction = splitReadyFromCache();
+    expect(
+      reducer(initialState, readyAction),
+    ).toEqual({
+      ...initialState,
+      isReadyFromCache: true,
       lastUpdate: readyAction.payload.timestamp,
     });
   });

--- a/src/__tests__/utils/mockBrowserSplitSdk.ts
+++ b/src/__tests__/utils/mockBrowserSplitSdk.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 export const Event = {
   SDK_READY_TIMED_OUT: 'init::timeout',
   SDK_READY: 'init::ready',
+  SDK_READY_FROM_CACHE: 'init::cache-ready',
   SDK_UPDATE: 'state::update',
 };
 
@@ -29,11 +30,14 @@ export function mockSdk() {
 
     function mockClient(key?: SplitIO.SplitKey) {
       // Readiness
-      let __isReady__ = false;
-      let __isTimedout__ = false;
+      let __isReady__: boolean | undefined;
+      let __isReadyFromCache__: boolean | undefined;
+      let __hasTimedout__: boolean | undefined;
+      let __isDestroyed__: boolean | undefined;
       const __emitter__ = new EventEmitter();
       __emitter__.once(Event.SDK_READY, () => { __isReady__ = true; });
-      __emitter__.once(Event.SDK_READY_TIMED_OUT, () => { __isTimedout__ = true; });
+      __emitter__.once(Event.SDK_READY_FROM_CACHE, () => { __isReadyFromCache__ = true; });
+      __emitter__.once(Event.SDK_READY_TIMED_OUT, () => { __hasTimedout__ = true; });
 
       // Client methods
       const track: jest.Mock = jest.fn((tt, et, v, p) => {
@@ -54,10 +58,33 @@ export function mockSdk() {
       const ready: jest.Mock = jest.fn(() => {
         return new Promise((res, rej) => {
           __isReady__ ? res() : __emitter__.on(Event.SDK_READY, res);
-          __isTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
+          __hasTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
         });
       });
+      const context = {
+        constants: {
+          READY: 'is_ready',
+          READY_FROM_CACHE: 'is_ready_from_cache',
+          HAS_TIMEDOUT: 'has_timedout',
+          DESTROYED: 'is_destroyed',
+        },
+        get(name: string, flagCheck: boolean = false): boolean | undefined {
+          if (flagCheck !== true) throw new Error('Don\'t use promise result on SDK context');
+          switch (name) {
+            case this.constants.READY:
+              return __isReady__;
+            case this.constants.READY_FROM_CACHE:
+              return __isReadyFromCache__;
+            case this.constants.HAS_TIMEDOUT:
+              return __hasTimedout__;
+            case this.constants.DESTROYED:
+              return __isDestroyed__;
+          }
+          throw new Error(`We shouldn't be accessing property "${name}" from the context`);
+        },
+      };
       const destroy: jest.Mock = jest.fn(() => {
+        __isDestroyed__ = true;
         return new Promise((res, rej) => { setTimeout(res, 100); });
       });
 
@@ -69,6 +96,8 @@ export function mockSdk() {
         Event,
         // EventEmitter exposed to trigger events manually
         __emitter__,
+        // Client context exposed to get readiness status (READY, READY_FROM_CACHE, HAS_TIMEDOUT, DESTROYED)
+        __context: context,
       });
     }
 

--- a/src/__tests__/utils/mockNodeSplitSdk.ts
+++ b/src/__tests__/utils/mockNodeSplitSdk.ts
@@ -8,11 +8,12 @@ export const Event = {
 
 function mockClient() {
   // Readiness
-  let __isReady__ = false;
-  let __isTimedout__ = false;
+  let __isReady__: boolean | undefined;
+  let __hasTimedout__: boolean | undefined;
+  let __isDestroyed__: boolean | undefined;
   const __emitter__ = new EventEmitter();
   __emitter__.once(Event.SDK_READY, () => { __isReady__ = true; });
-  __emitter__.once(Event.SDK_READY_TIMED_OUT, () => { __isTimedout__ = true; });
+  __emitter__.once(Event.SDK_READY_TIMED_OUT, () => { __hasTimedout__ = true; });
 
   // Client methods
   const track: jest.Mock = jest.fn(() => {
@@ -24,10 +25,31 @@ function mockClient() {
   const ready: jest.Mock = jest.fn(() => {
     return new Promise((res, rej) => {
       __isReady__ ? res() : __emitter__.on(Event.SDK_READY, res);
-      __isTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
+      __hasTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
     });
   });
+  const context = {
+    constants: {
+      READY: 'is_ready',
+      READY_FROM_CACHE: 'is_ready_from_cache',
+      HAS_TIMEDOUT: 'has_timedout',
+      DESTROYED: 'is_destroyed',
+    },
+    get(name: string, flagCheck: boolean = false): boolean | undefined {
+      if (flagCheck !== true) throw new Error('Don\'t use promise result on SDK context');
+      switch (name) {
+        case this.constants.READY:
+          return __isReady__;
+        case this.constants.HAS_TIMEDOUT:
+          return __hasTimedout__;
+        case this.constants.DESTROYED:
+          return __isDestroyed__;
+      }
+      throw new Error(`We shouldn't be accessing property "${name}" from the context`);
+    },
+  };
   const destroy: jest.Mock = jest.fn(() => {
+    __isDestroyed__ = true;
     return new Promise((res, rej) => { setTimeout(res, 100); });
   });
 
@@ -39,6 +61,8 @@ function mockClient() {
     Event,
     // EventEmitter exposed to trigger events manually
     __emitter__,
+    // Client context exposed to get readiness status (READY, HAS_TIMEDOUT, DESTROYED)
+    __context: context,
   });
 }
 

--- a/src/__tests__/utils/storeState.ts
+++ b/src/__tests__/utils/storeState.ts
@@ -12,6 +12,7 @@ export const USER_INVALID = 'user_invalid';
 export const STATE_READY: { splitio: ISplitState } = {
   splitio: {
     isReady: true,
+    isReadyFromCache: false,
     isTimedout: false,
     hasTimedout: false,
     isDestroyed: false,
@@ -30,6 +31,7 @@ export const STATE_READY: { splitio: ISplitState } = {
 export const STATE_INITIAL: { splitio: ISplitState } = {
   splitio: {
     isReady: false,
+    isReadyFromCache: false,
     isTimedout: false,
     hasTimedout: false,
     isDestroyed: false,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,12 +2,21 @@
  * Common action creators for browser and node.
  * They return plain actions (Flux-Standard-Actions).
  */
-import { SPLIT_READY, SPLIT_UPDATE, SPLIT_TIMEDOUT, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
+import { SPLIT_READY, SPLIT_READY_FROM_CACHE, SPLIT_UPDATE, SPLIT_TIMEDOUT, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
 import { matching } from './utils';
 
 export function splitReady() {
   return {
     type: SPLIT_READY,
+    payload: {
+      timestamp: Date.now(),
+    },
+  };
+}
+
+export function splitReadyFromCache() {
+  return {
+    type: SPLIT_READY_FROM_CACHE,
     payload: {
       timestamp: Date.now(),
     },

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -60,6 +60,7 @@ export function initSplitSdk(params: IInitSplitSdkParams): (dispatch: Dispatch<A
 
     // Add callback listeners
     if (params.onReady) defaultClient.once(defaultClient.Event.SDK_READY, params.onReady);
+    if (params.onReadyFromCache) defaultClient.once(defaultClient.Event.SDK_READY_FROM_CACHE, params.onReadyFromCache);
     if (params.onTimedout) defaultClient.once(defaultClient.Event.SDK_READY_TIMED_OUT, params.onTimedout);
     if (params.onUpdate) defaultClient.on(defaultClient.Event.SDK_UPDATE, params.onUpdate);
 

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -183,7 +183,7 @@ interface IClientNotDetached extends SplitIO.IClient {
 
 /**
  * Used in not detached version (browser). It gets an SDK client and enhances it with `evalOnUpdate` and `evalOnReady` lists.
- * This lists are used by `getTreatments` action creator to schedule evaluation of splits on SDK_READY and SDK_UPDATE events.
+ * These lists are used by `getTreatments` action creator to schedule evaluation of splits on SDK_READY and SDK_UPDATE events.
  * It is exported for testing purposes only.
  *
  * @param splitSdk it contains the Split factory, the store dispatch function, and other internal properties

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -1,9 +1,9 @@
 import { SplitFactory } from '@splitsoftware/splitio';
 import { Dispatch, Action } from 'redux';
 import { IInitSplitSdkParams, IGetTreatmentsParams, ISplitFactoryBuilder } from './types';
-import { splitReady, splitTimedout, splitUpdate, splitDestroy, addTreatments } from './actions';
+import { splitReady, splitReadyFromCache, splitTimedout, splitUpdate, splitDestroy, addTreatments } from './actions';
 import { VERSION, ERROR_GETT_NO_INITSPLITSDK, ERROR_DESTROY_NO_INITSPLITSDK, getControlTreatmentsWithConfig } from './constants';
-import { matching, promiseWrapper } from './utils';
+import { matching, promiseWrapper, getIsReady, getIsOperational } from './utils';
 
 /**
  * Internal object SplitSdk. This object should not be accessed or
@@ -147,12 +147,15 @@ export function getTreatments(params: IGetTreatmentsParams): Action | (() => voi
       __removeEvalOnUpdate(client, params);
     }
 
-    // Execute the action if the SDK is ready, or store it for execution when ready and store a control treatment
-    if (client.isReady) {
+    // If the SDK is not ready, it stores the action to execute when ready
+    if (!getIsReady(client)) {
+      client.evalOnReady.push(params);
+    }
+    if (getIsOperational(client)) {
+      // If the SDK is operational (i.e., it is ready or ready from cache), it evaluates and adds treatments to the store
       return __getTreatments(client, params);
     } else {
-      client.evalOnReady.push(params);
-      // In this case we dispatch an addTreatments with control treatments, without calling the SDK (no impressions sent)
+      // Otherwise, it adds control treatments to the store, without calling the SDK (no impressions sent)
       return addTreatments(params.key || (splitSdk.config as SplitIO.IBrowserSettings).core.key, getControlTreatmentsWithConfig(params.splitNames));
     }
 
@@ -172,19 +175,19 @@ export function getTreatments(params: IGetTreatmentsParams): Action | (() => voi
 interface IClientNotDetached extends SplitIO.IClient {
   _trackingStatus?: boolean;
   isReady: boolean;
+  isReadyFromCache: boolean;
   evalOnUpdate: { [splitNameSplitKeyPair: string]: IGetTreatmentsParams }; // redoOnUpdateOrReady
   evalOnReady: IGetTreatmentsParams[]; // waitUntilReady
 }
 
 /**
- * Used in not detached version (browser). It gets an SDK client and enhance it with additional properties:
- *  - `isReady` status property.
- *  - `evalOnUpdate` and `evalOnReady` action lists.
+ * Used in not detached version (browser). It gets an SDK client and enhances it with `evalOnUpdate` and `evalOnReady` lists.
+ * This lists are used by `getTreatments` action creator to schedule evaluation of splits on SDK_READY and SDK_UPDATE events.
  * It is exported for testing purposes only.
  *
  * @param splitSdk it contains the Split factory, the store dispatch function, and other internal properties
  * @param key optional user key
- * @returns SDK client with `isReady` and `isTimeout` status properties
+ * @returns SDK client with `evalOnUpdate` and `evalOnReady` action lists.
  */
 export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientNotDetached {
 
@@ -197,7 +200,6 @@ export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientN
 
   if (!isMainClient) splitSdk.sharedClients[stringKey] = client;
   client._trackingStatus = true;
-  client.isReady = false;
   client.evalOnUpdate = {}; // getTreatment actions stored to execute on SDK update
   client.evalOnReady = []; // getTreatment actions stored to execute when the SDK is ready
 
@@ -205,7 +207,6 @@ export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientN
 
   // On SDK ready, evaluate the registered `getTreatments` actions and dispatch `splitReady` action for the main client
   function onReady() {
-    client.isReady = true;
     if (!key) splitSdk.dispatch(splitReady());
     client.evalOnReady.forEach((params) =>
       splitSdk.dispatch(__getTreatments(client, params)),
@@ -218,6 +219,10 @@ export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientN
     if (!key) splitSdk.dispatch(splitTimedout());
     // register a listener for SDK_READY event, that might trigger after a timeout
     client.once(client.Event.SDK_READY, onReady);
+  });
+
+  client.once(client.Event.SDK_READY_FROM_CACHE, function() {
+    if (!key) splitSdk.dispatch(splitReadyFromCache());
   });
 
   // On SDK update, evaluate the registered `getTreatments` actions and dispatch `splitUpdate` action for the main client

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,8 @@ export const getControlTreatmentsWithConfig = (splitNames: string[]): SplitIO.Tr
 // Action types
 export const SPLIT_READY = 'SPLIT_READY';
 
+export const SPLIT_READY_FROM_CACHE = 'SPLIT_READY_FROM_CACHE';
+
 export const SPLIT_UPDATE = 'SPLIT_UPDATE';
 
 export const SPLIT_TIMEDOUT = 'SPLIT_TIMEDOUT';

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,12 +1,13 @@
 import { Reducer } from 'redux';
 import { ISplitState } from './types';
-import { SPLIT_READY, SPLIT_TIMEDOUT, SPLIT_UPDATE, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
+import { SPLIT_READY, SPLIT_READY_FROM_CACHE, SPLIT_TIMEDOUT, SPLIT_UPDATE, SPLIT_DESTROY, ADD_TREATMENTS } from './constants';
 
 /**
  * Initial default state for Split reducer
  */
 const initialState: ISplitState = {
   isReady: false,
+  isReadyFromCache: false,
   isTimedout: false,
   hasTimedout: false,
   isDestroyed: false,
@@ -28,6 +29,13 @@ const splitReducer: Reducer<ISplitState> = function(
         ...state,
         isReady: true,
         isTimedout: false,
+        lastUpdate: action.payload.timestamp,
+      };
+
+    case SPLIT_READY_FROM_CACHE:
+      return {
+        ...state,
+        isReadyFromCache: true,
         lastUpdate: action.payload.timestamp,
       };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,19 +2,27 @@
 export interface ISplitState {
 
   /**
-   * isReady indicates if Split SDK is ready, i.e., if it has triggered an SDK_READY event.
+   * isReady indicates if Split SDK is ready, i.e., if it has emitted an SDK_READY event.
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
    */
   isReady: boolean;
 
   /**
-   * isTimedout indicates if the Split SDK has triggered an SDK_READY_TIMED_OUT event and is not ready.
+   * isReadyFromCache indicates if Split SDK has emitted an SDK_READY_FROM_CACHE event, what means that the SDK is ready to
+   * evaluate using LocalStorage cached data (which might be stale).
+   * This flag only applies for the Browser if using LOCALSTORAGE as storage type.
+   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
+   */
+  isReadyFromCache: boolean;
+
+  /**
+   * isTimedout indicates if the Split SDK has emitted an SDK_READY_TIMED_OUT event and is not ready.
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
    */
   isTimedout: boolean;
 
   /**
-   * hasTimedout indicates if the Split SDK has ever triggered an SDK_READY_TIMED_OUT event.
+   * hasTimedout indicates if the Split SDK has ever emitted an SDK_READY_TIMED_OUT event.
    * It's meant to keep a reference that the SDK emitted a timeout at some point, not the current state.
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#advanced-subscribe-to-events-and-changes}
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,11 @@ export interface IInitSplitSdkParams {
   onReady?: () => any;
 
   /**
+   * optional callback to be invoked on SDK_READY_FROM_CACHE event
+   */
+  onReadyFromCache?: () => any;
+
+  /**
    * optional callback to be invoked on SDK_READY_TIMED_OUT event
    */
   onTimedout?: () => any;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,3 +54,32 @@ export function promiseWrapper(customPromise: Promise<any>, defaultOnRejected: (
 
   return chain(customPromise);
 }
+
+// The following utils might be removed in the future, if the JS SDK extends its public API with a "getStatus" method
+
+/**
+ * ClientWithContext interface.
+ */
+interface IClientWithContext extends SplitIO.IClient {
+  __context: {
+    constants: {
+      READY: 'is_ready',
+      READY_FROM_CACHE: 'is_ready_from_cache',
+      HAS_TIMEDOUT: 'has_timedout',
+      DESTROYED: 'is_destroyed',
+    },
+    get: (name: string, flagCheck: boolean) => boolean | undefined,
+  };
+}
+
+export function getIsReady(client: SplitIO.IClient): boolean {
+  return (client as IClientWithContext).__context.get((client as IClientWithContext).__context.constants.READY, true) ? true : false;
+}
+
+export function getIsReadyFromCache(client: SplitIO.IClient): boolean {
+  return (client as IClientWithContext).__context.get((client as IClientWithContext).__context.constants.READY_FROM_CACHE, true) ? true : false;
+}
+
+export function getIsOperational(client: SplitIO.IClient): boolean {
+  return getIsReady(client) || getIsReadyFromCache(client);
+}


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?

- Added `isReadyFromCache` status property to Split's piece of state, which is set to `true` if the `SDK_READY_FROM_CACHE` event is emitted (only applies for browser when using LOCALSTORAGE as storage type).
- Added `onReadyFromCache` param in `initSplitSdk` action creator, to let the user attack a listener for SDK_READY_FROM_CACHE event.
- `getTreatments` will immediately evaluate treatments if the SDK is operational, i.e., if either `isReady` or `isReadyFromCache` are true. If not operational, `getTreatments` keeps the same logic of adding control treatments to the store, without calling the SDK (no impressions).

## How do we test the changes introduced in this PR?

- Unit and integration tests

## Extra Notes