### PR TITLE
Polishing server side

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,8 @@
 1.2.0 (Jul XX, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.13.0, which uses streaming synchronization by default, amongst other updates. Learn more in our javascript-client changelog or documentation.
  - Added a new status property to split's piece of state: `isReadyFromCache`, to indicate that the SDK is ready to evaluate when using LocalStorage cached data in browser.
- - Added optional callback parameter to `initSplitSdk` action creator: `onReadyFromCache`, to listen when the SDK is ready to evaluate using LocalStorage cached data.
- - Added optional callback parameter to `destroySplitSdk` action creator: `onDestroy`, to listen when the SDK has gracefully shut down.
+ - Added an optional callback parameter to `initSplitSdk` action creator: `onReadyFromCache`, to listen when the SDK is ready to evaluate using LocalStorage cached data.
+ - Added an optional callback parameter to `destroySplitSdk` action creator: `onDestroy`, to listen when the SDK has gracefully shut down.
 
 1.1.0 (May 11, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 1.2.0 (Jul XX, 2020)
  - Updated @splitsoftware/splitio dependency to version 10.13.0, which uses streaming synchronization by default, amongst other updates. Learn more in our javascript-client changelog or documentation.
- - Added a new status property to split's piece of state: `isReadyFromCache` to indicate that the SDK is ready to evaluate when using LocalStorage cached data in browser.
- - Added a new callback parameter to `initSplitSdk` action creator: `onReadyFromCache` to listen when the SDK is ready to evaluate using LocalStorage cached data.
+ - Added a new status property to split's piece of state: `isReadyFromCache`, to indicate that the SDK is ready to evaluate when using LocalStorage cached data in browser.
+ - Added optional callback parameter to `initSplitSdk` action creator: `onReadyFromCache`, to listen when the SDK is ready to evaluate using LocalStorage cached data.
+ - Added optional callback parameter to `destroySplitSdk` action creator: `onDestroy`, to listen when the SDK has gracefully shut down.
 
 1.1.0 (May 11, 2020)
  - Bugfixing - incorrect evaluation of splits on browser when using `getTreatments` with a different user key than the default, caused by not waiting the fetch of segments.

--- a/src/__tests__/actions.browser.test.ts
+++ b/src/__tests__/actions.browser.test.ts
@@ -472,17 +472,12 @@ describe('destroySplitSdk', () => {
       store.dispatch<any>(destroySplitSdk({ onDestroy: onDestroyCb }));
 
       function onDestroyCb() {
-        // the cb is invoked before the splitDestroy action is dispatched
-        expect(store.getActions().length).toEqual(1);
         // assert that all client's destroy methods were called
         expect((splitSdk.factory as any).client().destroy.mock.calls.length).toBe(1);
 
-        // check store updated on a following event-loop cycle
-        setTimeout(() => {
-          const action = store.getActions()[1];
-          expect(action.type).toEqual(SPLIT_DESTROY);
-          done();
-        }, 0);
+        const action = store.getActions()[1];
+        expect(action.type).toEqual(SPLIT_DESTROY);
+        done();
       }
     });
   });

--- a/src/__tests__/actions.node.test.ts
+++ b/src/__tests__/actions.node.test.ts
@@ -16,49 +16,65 @@ const splitKey = 'user1';
 /** Test targets */
 import { initSplitSdk, getTreatments, destroySplitSdk, splitSdk } from '../asyncActions';
 
+function clearSplitSdk() {
+  splitSdk.config = null;
+  splitSdk.splitio = null;
+  splitSdk.factory = null;
+  splitSdk.sharedClients = {};
+  splitSdk.isDetached = false;
+  splitSdk.dispatch = null;
+}
+
 describe('initSplitSdk', () => {
 
-  beforeEach(() => {
-    splitSdk.factory = null;
-    splitSdk.config = null;
-  });
+  beforeEach(clearSplitSdk);
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('invokes callbacks and dispatches SPLIT_READY actions when SDK_READY event is triggered', (done) => {
+  it('invokes onReady callback once and dispatches SPLIT_READY action if SDK_READY event was triggered', (done) => {
     const onUpdateCb = jest.fn();
     const initSplitSdkAction = initSplitSdk({ config: sdkNodeConfig, onReady: onReadyCb, onUpdate: onUpdateCb });
     expect(splitSdk.config).toBe(sdkNodeConfig);
     expect(splitSdk.factory).toBeTruthy();
 
+    let onReadyCbFirstTime = true;
     const timestamp = Date.now();
     (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
 
     function onReadyCb() {
-      const store = mockStore(STATE_INITIAL);
-      store.dispatch<any>(initSplitSdkAction);
-      // Action is dispatched synchronously
-      const action = store.getActions()[0];
-      expect(action.type).toEqual(SPLIT_READY);
-      expect(action.payload.timestamp).toBeLessThanOrEqual(Date.now());
-      expect(action.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
-      expect((SplitFactory as jest.Mock).mock.calls.length).toBe(1);
+      if (!onReadyCbFirstTime) throw new Error('timeout callback should not be called more than once');
+      onReadyCbFirstTime = false;
 
+      function createStoreAndDispatchAction() {
+        const store = mockStore(STATE_INITIAL);
+        store.dispatch<any>(initSplitSdkAction);
+
+        // Action is dispatched synchronously
+        const action = store.getActions()[0];
+        expect(action.type).toEqual(SPLIT_READY);
+        expect(action.payload.timestamp).toBeLessThanOrEqual(Date.now());
+        expect(action.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+      }
+
+      // create multiple stores
+      for (let i = 0; i < 3; i++) createStoreAndDispatchAction();
+
+      // invoke onUpdate callback each time SDK_UPDATE is emitted
       (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_UPDATE);
-      expect(onUpdateCb.mock.calls.length).toBe(1);
-
-      // @TODO test that callbacks are called only once when the thunk action is dispatched in multiple stores
+      (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_UPDATE);
+      expect(onUpdateCb.mock.calls.length).toBe(2);
+      expect((SplitFactory as jest.Mock).mock.calls.length).toBe(1);
       done();
     }
   });
 
-  it('invokes callbacks and dispatches SPLIT_TIMEDOUT and then SPLIT_READY actions when SDK_READY_TIMED_OUT and SDK_READY events are triggered', (done) => {
+  it('invokes onReady and onTimedout callbacks once and dispatches SPLIT_TIMEDOUT and SPLIT_READY actions if SDK_READY_TIMED_OUT and SDK_READY events were triggered', (done) => {
     const initSplitSdkAction = initSplitSdk({ config: sdkNodeConfig, onReady: onReadyCb, onTimedout: onTimedoutCb });
+
     let onTimeoutCbFirstTime = true;
     let onReadyCbFirstTime = true;
-
     let timestamp = Date.now();
     (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY_TIMED_OUT);
 
@@ -83,45 +99,46 @@ describe('initSplitSdk', () => {
       if (!onReadyCbFirstTime) throw new Error('ready callback should not be called more than once');
       onReadyCbFirstTime = false;
 
-      const store = mockStore(STATE_INITIAL);
-      store.dispatch<any>(initSplitSdkAction);
-      // Actions are dispatched synchronously
-      const timeoutAction = store.getActions()[0];
-      expect(timeoutAction.type).toEqual(SPLIT_TIMEDOUT);
-      expect(timeoutAction.payload.timestamp).toBeLessThanOrEqual(Date.now());
-      expect(timeoutAction.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+      function createStoreAndDispatchActions() {
+        const store = mockStore(STATE_INITIAL);
+        store.dispatch<any>(initSplitSdkAction);
 
-      const readyAction = store.getActions()[1];
-      expect(readyAction.type).toEqual(SPLIT_READY);
-      expect(readyAction.payload.timestamp).toBeLessThanOrEqual(Date.now());
-      expect(readyAction.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+        // Actions are dispatched synchronously
+        const timeoutAction = store.getActions()[0];
+        expect(timeoutAction.type).toEqual(SPLIT_TIMEDOUT);
+        expect(timeoutAction.payload.timestamp).toBeLessThanOrEqual(Date.now());
+        expect(timeoutAction.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+
+        const readyAction = store.getActions()[1];
+        expect(readyAction.type).toEqual(SPLIT_READY);
+        expect(readyAction.payload.timestamp).toBeLessThanOrEqual(Date.now());
+        expect(readyAction.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
+      }
+
+      // create multiple stores
+      for (let i = 0; i < 3; i++) createStoreAndDispatchActions();
 
       done();
     }
   });
 
-  // @TODO fix this test
-  // it('returns a promise that rejects on SDK_READY_TIMED_OUT', async (done) => {
-  //   const store = mockStore(STATE_INITIAL);
-  //   try {
-  //     setTimeout(() => { (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY_TIMED_OUT, 'SDK_READY_TIMED_OUT'); }, 100);
-  //     await store.dispatch<any>(initSplitSdk({ config: sdkNodeConfig }));
-  //   } catch (error) {
-  //     expect(error.includes('SDK_READY_TIMED_OUT'));
-  //     done();
-  //   } finally {
-  //     console.log('sapee');
-  //   }
-  // });
+  it('returns a promise that rejects on SDK_READY_TIMED_OUT', async (done) => {
+    const store = mockStore(STATE_INITIAL);
+    try {
+      const initSplitSdkAction = initSplitSdk({ config: sdkNodeConfig });
+      setTimeout(() => { (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY_TIMED_OUT, 'SDK_READY_TIMED_OUT'); }, 100);
+      await store.dispatch<any>(initSplitSdkAction);
+    } catch (error) {
+      expect(error.includes('SDK_READY_TIMED_OUT'));
+      done();
+    }
+  });
 
 });
 
 describe('getTreatments', () => {
 
-  beforeEach(() => {
-    splitSdk.factory = null;
-    splitSdk.config = null;
-  });
+  beforeEach(clearSplitSdk);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -144,28 +161,34 @@ describe('getTreatments', () => {
     (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
 
     function onReadyCb() {
-      const store = mockStore(STATE_INITIAL);
-      store.dispatch<any>(initSplitSdkAction);
 
-      // Invoke with a Split name string and no attributes
-      store.dispatch<any>(getTreatments({ key: splitKey, splitNames: 'split1' }));
+      function createStoreAndDispatchActions() {
+        const store = mockStore(STATE_INITIAL);
+        store.dispatch<any>(initSplitSdkAction);
 
-      let action = store.getActions()[1];
-      expect(action.type).toBe(ADD_TREATMENTS);
-      expect(action.payload.key).toBe(splitKey);
-      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveBeenLastCalledWith(splitKey, ['split1'], undefined);
-      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
+        // Invoke with a Split name string and no attributes
+        store.dispatch<any>(getTreatments({ key: splitKey, splitNames: 'split1' }));
 
-      // Invoke with a list of Split names and a attributes object
-      const splitNames = ['split1', 'split2'];
-      const attributes = { att1: 'att1' };
-      store.dispatch<any>(getTreatments({ key: splitKey, splitNames, attributes }));
+        let action = store.getActions()[1]; // action 0 is SPLIT_READY
+        expect(action.type).toBe(ADD_TREATMENTS);
+        expect(action.payload.key).toBe(splitKey);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveBeenLastCalledWith(splitKey, ['split1'], undefined);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
 
-      action = store.getActions()[2];
-      expect(action.type).toBe(ADD_TREATMENTS);
-      expect(action.payload.key).toBe(splitKey);
-      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveBeenLastCalledWith(splitKey, splitNames, attributes);
-      expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
+        // Invoke with a list of Split names and a attributes object
+        const splitNames = ['split1', 'split2'];
+        const attributes = { att1: 'att1' };
+        store.dispatch<any>(getTreatments({ key: splitKey, splitNames, attributes }));
+
+        action = store.getActions()[2];
+        expect(action.type).toBe(ADD_TREATMENTS);
+        expect(action.payload.key).toBe(splitKey);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveBeenLastCalledWith(splitKey, splitNames, attributes);
+        expect((splitSdk.factory as any).client().getTreatmentsWithConfig).toHaveLastReturnedWith(action.payload.treatments);
+      }
+
+      // create multiple stores
+      for (let i = 0; i < 3; i++) createStoreAndDispatchActions();
 
       done();
     }
@@ -175,10 +198,7 @@ describe('getTreatments', () => {
 
 describe('destroySplitSdk', () => {
 
-  beforeEach(() => {
-    splitSdk.factory = null;
-    splitSdk.config = null;
-  });
+  beforeEach(clearSplitSdk);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -186,39 +206,45 @@ describe('destroySplitSdk', () => {
 
   it('logs error and dispatches a no-op async action that returns a resolved promise if Split SDK was not initialized', () => {
     const errorSpy = jest.spyOn(console, 'error');
-    const store = mockStore(STATE_INITIAL);
 
-    store.dispatch<any>(destroySplitSdk()).then(() => {
-      expect(errorSpy).toBeCalledWith(ERROR_DESTROY_NO_INITSPLITSDK);
-      expect(store.getActions().length).toBe(0);
-    });
+    destroySplitSdk();
+    expect(errorSpy).toBeCalledWith(ERROR_DESTROY_NO_INITSPLITSDK);
   });
 
-  // @TODO refactor the following test
+  it('shuts down de SDK and invokes onDestroy callback', (done) => {
+    const initSplitSdkAction = initSplitSdk({ config: sdkNodeConfig });
+    (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
 
-  // it('returns a promise and dispatch SPLIT_DESTROY actions when clients are destroyed', (done) => {
-  //   const store = mockStore(STATE_INITIAL);
-  //   const actionResult = store.dispatch<any>(initSplitSdk({ config: sdkNodeConfig }));
-  //   (splitSdk.factory as any).client().__emitter__.emit(Event.SDK_READY);
+    const store = mockStore(STATE_INITIAL);
+    const actionResult = store.dispatch<any>(initSplitSdkAction);
 
-  //   actionResult.then(() => {
-  //     // we dispatch some `getTreatments` with different user keys
-  //     store.dispatch<any>(getTreatments({ splitNames: 'split2', key: 'other-user-key' }));
-  //     store.dispatch<any>(getTreatments({ splitNames: 'split3', key: 'other-user-key-2' }));
+    actionResult.then(() => {
+      // we dispatch some `getTreatments` with different user keys
+      store.dispatch<any>(getTreatments({ splitNames: 'split2', key: 'other-user-key' }));
+      store.dispatch<any>(getTreatments({ splitNames: 'split3', key: 'other-user-key-2' }));
 
-  //     const timestamp = Date.now();
-  //     const actionResult = store.dispatch<any>(destroySplitSdk());
+      const timestamp = Date.now();
+      destroySplitSdk({ onDestroy: onDestroyCb });
 
-  //     actionResult.then(() => {
-  //       const action = store.getActions()[3];
-  //       expect(action.type).toEqual(SPLIT_DESTROY);
-  //       expect(action.payload.timestamp).toBeLessThanOrEqual(Date.now());
-  //       expect(action.payload.timestamp).toBeGreaterThanOrEqual(timestamp);
-  //       // assert that the client destroy method was called
-  //       expect((splitSdk.factory as any).client().destroy.mock.calls.length).toBe(1);
-  //       done();
-  //     }, 0);
-  //   });
-  // });
+      function onDestroyCb() {
+        // assert that the client destroy method was called
+        expect((splitSdk.factory as any).client().destroy.mock.calls.length).toBe(1);
+
+        // the store created before destroy has 3 actions: SPLIT_READY and ADD_TREATMENTS x 2
+        expect(store.getActions().length).toEqual(3);
+
+        // new store created after destroy has 2 actions: SPLIT_READY and SPLIT_DESTROY
+        const newStoreAfterDestroy = mockStore(STATE_INITIAL);
+        newStoreAfterDestroy.dispatch<any>(initSplitSdkAction);
+
+        let action = newStoreAfterDestroy.getActions()[0];
+        expect(action.type).toEqual(SPLIT_READY);
+        action = newStoreAfterDestroy.getActions()[1];
+        expect(action.type).toEqual(SPLIT_DESTROY);
+
+        done();
+      }
+    });
+  });
 
 });

--- a/src/__tests__/utils/mockBrowserSplitSdk.ts
+++ b/src/__tests__/utils/mockBrowserSplitSdk.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import promiseWrapper from './promiseWrapper';
 
 export const Event = {
   SDK_READY_TIMED_OUT: 'init::timeout',
@@ -56,10 +57,10 @@ export function mockSdk() {
         return 'getTreatmentsWithConfig';
       });
       const ready: jest.Mock = jest.fn(() => {
-        return new Promise((res, rej) => {
+        return promiseWrapper(new Promise((res, rej) => {
           __isReady__ ? res() : __emitter__.on(Event.SDK_READY, res);
           __hasTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
-        });
+        }), () => { });
       });
       const context = {
         constants: {

--- a/src/__tests__/utils/mockNodeSplitSdk.ts
+++ b/src/__tests__/utils/mockNodeSplitSdk.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import promiseWrapper from './promiseWrapper';
 
 export const Event = {
   SDK_READY_TIMED_OUT: 'init::timeout',
@@ -23,10 +24,10 @@ function mockClient() {
     return 'getTreatmentsWithConfig';
   });
   const ready: jest.Mock = jest.fn(() => {
-    return new Promise((res, rej) => {
+    return promiseWrapper(new Promise((res, rej) => {
       __isReady__ ? res() : __emitter__.on(Event.SDK_READY, res);
       __hasTimedout__ ? rej() : __emitter__.on(Event.SDK_READY_TIMED_OUT, rej);
-    });
+    }), () => { });
   });
   const context = {
     constants: {

--- a/src/__tests__/utils/promiseWrapper.ts
+++ b/src/__tests__/utils/promiseWrapper.ts
@@ -1,0 +1,49 @@
+/**
+ * wraps a given promise in a new one with a default onRejected function,
+ * that handles the promise rejection if not other onRejected handler is provided.
+ *
+ * Caveats: there are some cases where the `defaultOnRejected` handler is not invoked
+ * and the promise rejection must be handled by the user (same as the Promise spec):
+ *  - using async/await syntax
+ *  - setting an `onFinally` handler as the first handler (e.g. `promiseWrapper(Promise.reject()).finally(...)`)
+ *  - setting more than one handler with at least one of them being an onRejected handler
+ *
+ * @param customPromise promise to wrap
+ * @param defaultOnRejected default onRejected function
+ * @returns a promise that doesn't need to be handled for rejection (except when using async/await syntax).
+ */
+export default function promiseWrapper(customPromise: Promise<any>, defaultOnRejected: (_: any) => any): Promise<any> {
+
+  let hasOnRejected = false;
+
+  function chain(promise: Promise<any>) {
+    const newPromise: Promise<any> = new Promise((res, rej) => {
+      return promise.then(
+        res,
+        function(value: any) {
+          if (hasOnRejected) {
+            rej(value);
+          } else {
+            defaultOnRejected(value);
+          }
+        },
+      );
+    });
+
+    const originalThen = newPromise.then;
+
+    newPromise.then = function(onfulfilled?: any, onrejected?: any) {
+      const result: Promise<any> = originalThen.call(newPromise, onfulfilled, onrejected);
+      if (typeof onrejected === 'function') {
+        hasOnRejected = true;
+        return result;
+      } else {
+        return chain(result);
+      }
+    };
+
+    return newPromise;
+  }
+
+  return chain(customPromise);
+}

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -211,7 +211,7 @@ export function getClient(splitSdk: ISplitSdk, key?: SplitIO.SplitKey): IClientN
  * Once the action is resolved, any subsequent dispatch of `getTreatments`
  * will update your treatments at the store with the `control` value.
  */
-export function destroySplitSdk(params?: IDestroySplitSdkParams): (dispatch: Dispatch<Action>) => Promise<void> {
+export function destroySplitSdk(params: IDestroySplitSdkParams = {}): (dispatch: Dispatch<Action>) => Promise<void> {
   // Log error message if the SDK was not initiated with a `initSplitSdk` action
   if (!splitSdk.factory) {
     console.error(ERROR_DESTROY_NO_INITSPLITSDK);
@@ -228,7 +228,7 @@ export function destroySplitSdk(params?: IDestroySplitSdkParams): (dispatch: Dis
 
   // Add onDestroy callback listener. It is important for server-side, where the thunk action is not dispatched
   // and so the user cannot access the promise as follows: `store.dispatch(destroySplitSdk()).then(...)`
-  if (params && params.onDestroy) Promise.all(destroyPromises).then(params.onDestroy);
+  if (params.onDestroy) Promise.all(destroyPromises).then(params.onDestroy);
 
   // Return Thunk (async) action
   return (dispatch: Dispatch<Action>): Promise<void> => {

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -219,7 +219,7 @@ export function destroySplitSdk(params?: IDestroySplitSdkParams): (dispatch: Dis
   }
 
   // Destroy the client(s) outside the thunk action, since on server-side the action is not dispatched
-  // because stores have a life-span per session/request and there may not be one when server shut down.
+  // because stores have a life-span per session/request and there may not be one when server shuts down.
   const mainClient = splitSdk.factory.client();
   // in node, `splitSdk.sharedClients` is an empty object
   const sharedClients = splitSdk.sharedClients;

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -228,12 +228,17 @@ export function destroySplitSdk(params: IDestroySplitSdkParams = {}): (dispatch:
 
   // Add onDestroy callback listener. It is important for server-side, where the thunk action is not dispatched
   // and so the user cannot access the promise as follows: `store.dispatch(destroySplitSdk()).then(...)`
-  if (params.onDestroy) Promise.all(destroyPromises).then(params.onDestroy);
+  let dispatched = false;
+  if (params.onDestroy) Promise.all(destroyPromises).then(() => {
+    if (!dispatched) params.onDestroy();
+  });
 
   // Return Thunk (async) action
   return (dispatch: Dispatch<Action>): Promise<void> => {
+    dispatched = true;
     return Promise.all(destroyPromises).then(function() {
       dispatch(splitDestroy());
+      if (params.onDestroy) params.onDestroy();
     });
   };
 }

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -230,6 +230,7 @@ export function destroySplitSdk(params: IDestroySplitSdkParams = {}): (dispatch:
   // and so the user cannot access the promise as follows: `store.dispatch(destroySplitSdk()).then(...)`
   let dispatched = false;
   if (params.onDestroy) Promise.all(destroyPromises).then(() => {
+    // condition to avoid calling the callback twice, since it should be called preferably after the action has been dispatched
     if (!dispatched) params.onDestroy();
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,16 @@ export interface IGetTreatmentsParams {
 }
 
 /**
+ * Type of the param object passed to `destroySplitSdk` action creator.
+ */
+export interface IDestroySplitSdkParams {
+  /**
+   * optional callback to be invoked once the SDK has gracefully shut down
+   */
+  onDestroy?: () => any;
+}
+
+/**
  * Type of the param object passed to `track` function helper.
  */
 export interface ITrackParams {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,3 +40,11 @@ export function getIsReadyFromCache(client: SplitIO.IClient): boolean {
 export function getIsOperational(client: SplitIO.IClient): boolean {
   return getIsReady(client) || getIsReadyFromCache(client);
 }
+
+export function getHasTimedout(client: SplitIO.IClient): boolean {
+  return (client as IClientWithContext).__context.get((client as IClientWithContext).__context.constants.HAS_TIMEDOUT, true) ? true : false;
+}
+
+export function getIsDestroyed(client: SplitIO.IClient): boolean {
+  return (client as IClientWithContext).__context.get((client as IClientWithContext).__context.constants.DESTROYED, true) ? true : false;
+}


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?

- Updated `initSplitSdk` action creator to attach event listeners only once (not when the thunk action is dispatched). This is needed for server-side, where `initSplitSdk` is called once but the created thunk is dispatched each time a new store is created per request/session.

- Updated `destroySplitSdk` action creator to shut down the SDK before the thunk action is dispatched. This is needed for server-side, where `destroySplitSdk` is invoked without dispatching the thunk action.

- Added `onDestroy` callback parameter to `destroySplitSdk`, to listen when the SDK has gracefully shut down. This param is mainly needed for server-side, where the thunk action is not dispatched and so the user cannot access the destroy promise as in client-side: `store.dispatch(destroySplitSdk()).then(...)`.

## How do we test the changes introduced in this PR?

- E2E test to evaluate that event callbacks are invoked only once when `initSplitSdk` thunk is dispatched multiple times.
- E2E test to evaluate that `onDestroy` callback is invoked even when the returned `destroySplitSdk` thunk action is not dispatched.

## Extra Notes

- [DONE: onDestroy invoked preferably after action is dispatched] define if `onDestroy` callback must be invoked after `splitDestroy` action is dispatched or not.