### PR TITLE
AUT-1705: Adding SonarQube for redux-client.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
             -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
             -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+
       - name: SonarQube Scan (Pull Request)
         if: github.event_name == 'pull_request'
         uses: SonarSource/sonarcloud-github-action@v1.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up nodejs
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.16.0'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
 
       - name: SonarQube Scan (Push)
         if: github.event_name == 'push'
-        uses: SonarSource/sonarcloud-github-action@v1.6
+        uses: SonarSource/sonarcloud-github-action@v1.8
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         with:
@@ -52,7 +52,7 @@ jobs:
             -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
       - name: SonarQube Scan (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: SonarSource/sonarcloud-github-action@v1.6
+        uses: SonarSource/sonarcloud-github-action@v1.8
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: ci
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - development
+  push:
     branches:
       - '*'
 
@@ -13,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up nodejs
         uses: actions/setup-node@v2
@@ -28,7 +31,39 @@ jobs:
         run: npm run check
 
       - name: npm Test
-        run: npm run test
+        run: npm run test -- --coverage
 
       - name: npm Build
         run: npm run build
+
+      - name: SonarQube Scan (Push)
+        if: github.event_name == 'push'
+        uses: SonarSource/sonarcloud-github-action@v1.6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+      - name: SonarQube Scan (Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: SonarSource/sonarcloud-github-action@v1.6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.links.ci="https://github.com/splitio/${{ github.event.repository.name }}/actions"
+            -Dsonar.links.scm="https://github.com/splitio/${{ github.event.repository.name }}"
+            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?
Adding SonarQube step to CI in order have a check for code quality

Since main and development are two permanent branches, we are having two executions in order to make sonar to know about the parent branch.

## How do we test the changes introduced in this PR?
Testing from this PR if the step is being executed and giving the right output.

From SonarQube site this PR is being analyzed and showing code coverage.

https://sonarqube.split-internal.com/dashboard?id=redux-client&pullRequest=68
![Screen Shot 2022-12-15 at 09 25 26](https://user-images.githubusercontent.com/45567713/207858777-3a444cad-9bc2-46e4-b018-39aa540fc5d1.png)

Enabled decoration for PR:
![Screen Shot 2022-12-15 at 09 25 04](https://user-images.githubusercontent.com/45567713/207858828-9add1da0-b16f-4f24-b254-7fc2f80329b3.png)

## Extra Notes

In order to get the blame information to SonarQube, we told GitHubActions to clone the entire history. This was done on this section: 
```
      - name: Checkout code
        uses: actions/checkout@v3
        with:
          fetch-depth: 0
```

From SonarQube site I applied the following changes:

Set master & development branches as active branches.
Enabled PullRequest decoration
