### PR TITLE
allow importing type `ISplitState`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,3 +4,4 @@ export { track, getSplitNames, getSplit, getSplits } from './helpers';
 export { selectTreatmentValue, selectTreatmentWithConfig } from './selectors';
 export { connectSplit } from './react-redux/connectSplit';
 export { connectToggler, mapTreatmentToProps, mapIsFeatureOnToProps } from './react-redux/connectToggler';
+export { ISplitState } from './types'


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?
Allowing the export of type `ISplitState`

## How do we test the changes introduced in this PR?
It doesn't affect anything else functionality wise 

## Extra Notes
n/a