### PR TITLE
Rename build folders for consistency with other packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .DS_Store
-node_modules
-lib
-es
-types
-coverage
-examples
-.vscode
-.scannerwork
+/node_modules
+/cjs
+/esm
+/types
+/coverage
+/examples
+/.vscode
+/.scannerwork

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.0.0 (September XX, 2024)
+ - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for ECMAScript Modules build.
+
 1.14.1 (October 15, 2024)
  - Bugfixing - Fixed error in `splitReducer` when handling actions with a `null` payload, preventing crashes caused by accessing undefined payload properties (Related to https://github.com/splitio/redux-client/issues/121).
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@splitsoftware/splitio-redux",
   "version": "1.14.1",
   "description": "A library to easily use Split JS SDK with Redux and React Redux",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
   "types": "types/index.d.ts",
   "files": [
     "README.md",
@@ -11,12 +11,12 @@
     "LICENSE",
     "CHANGES.txt",
     "src",
-    "lib",
-    "es",
+    "cjs",
+    "esm",
     "types"
   ],
   "scripts": {
-    "build": "rimraf lib/* es/* types/* && tsc && tsc -m commonjs --outDir lib -d true --declarationDir types",
+    "build": "rimraf cjs/* esm/* types/* && tsc && tsc -m commonjs --outDir cjs -d true --declarationDir types",
     "postbuild": "./version_replace.sh",
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "eslint 'src/**/*.ts'",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": false,                       /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "es",                           /* Redirect output structure to the directory. */
+    "outDir": "esm",                           /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */

--- a/version_replace.sh
+++ b/version_replace.sh
@@ -2,7 +2,7 @@
 
 VERSION=$(node -e "(function () { console.log(require('./package.json').version) })()")
 
-replace 'REDUX_SDK_VERSION_NUMBER' $VERSION ./lib/constants.js ./es/constants.js
+replace 'REDUX_SDK_VERSION_NUMBER' $VERSION ./cjs/constants.js ./esm/constants.js
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?

`/lib` -> `/cjs`, `/es` -> `/esm`.

## How do we test the changes introduced in this PR?

## Extra Notes
