### PR TITLE
Update `getTreatments` action creator to not dispatch unnecessary actions while the SDK is not operational

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 2.0.0 (November 15, 2024)
  - Added support for targeting rules based on large segments.
  - Updated @splitsoftware/splitio package to version 11.0.1 that includes major updates, and updated some transitive dependencies for vulnerability fixes.
+ - Updated `getTreatments` action creator to not dispatch an action when called while the SDK is not ready or ready from cache, to avoid unnecessary updates in the state.
  - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for ECMAScript Modules build.
  - BREAKING CHANGES:
       - Removed the `core.trafficType` option from the `config` object accepted by the `initSplitSdk` action creator, and made the `trafficType` argument of the `track` helper function mandatory.

--- a/src/asyncActions.ts
+++ b/src/asyncActions.ts
@@ -3,7 +3,7 @@ import { SplitFactory as SplitFactoryForLocalhost } from '@splitsoftware/splitio
 import { Dispatch, Action } from 'redux';
 import { IInitSplitSdkParams, IGetTreatmentsParams, IDestroySplitSdkParams, ISplitFactoryBuilder } from './types';
 import { splitReady, splitReadyWithEvaluations, splitReadyFromCache, splitReadyFromCacheWithEvaluations, splitTimedout, splitUpdate, splitUpdateWithEvaluations, splitDestroy, addTreatments } from './actions';
-import { VERSION, ERROR_GETT_NO_INITSPLITSDK, ERROR_DESTROY_NO_INITSPLITSDK, getControlTreatmentsWithConfig } from './constants';
+import { VERSION, ERROR_GETT_NO_INITSPLITSDK, ERROR_DESTROY_NO_INITSPLITSDK } from './constants';
 import { matching, __getStatus, validateGetTreatmentsParams, isMainClient } from './utils';
 
 /**
@@ -164,10 +164,7 @@ export function getTreatments(params: IGetTreatmentsParams): Action | (() => voi
         splitReadyFromCacheWithEvaluations(params.key, treatments, status.lastUpdate, true) :
         addTreatments(params.key || (splitSdk.config as SplitIO.IBrowserSettings).core.key, treatments);
     } else {
-      // Otherwise, it adds control treatments to the store, without calling the SDK (no impressions sent)
-      // With flag sets, an empty object is passed since we don't know their feature flag names
-      // @TODO remove eventually to minimize state changes
-      return addTreatments(params.key || (splitSdk.config as SplitIO.IBrowserSettings).core.key, splitNames ? getControlTreatmentsWithConfig(splitNames) : {});
+      return () => { };
     }
 
   } else { // Split SDK running in Node.js

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,13 +15,6 @@ export const CONTROL_WITH_CONFIG: SplitIO.TreatmentWithConfig = {
   config: null,
 };
 
-export const getControlTreatmentsWithConfig = (featureFlagNames: string[]): SplitIO.TreatmentsWithConfig => {
-  return featureFlagNames.reduce((pValue: SplitIO.TreatmentsWithConfig, cValue: string) => {
-    pValue[cValue] = CONTROL_WITH_CONFIG;
-    return pValue;
-  }, {});
-};
-
 // Action types
 export const SPLIT_READY = 'SPLIT_READY';
 


### PR DESCRIPTION
# Redux SDK

## What did you accomplish?

Update `getTreatments` action creator to not dispatch ADD_TREATMENTS actions while the SDK is not operational, to avoid unnecessary updates of the state.

## How do we test the changes introduced in this PR?

Unit tests.

## Extra Notes
